### PR TITLE
Added batch file for Windows support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+bin/moodle-docker-compose.cmd eol=crlf

--- a/bin/moodle-docker-compose.cmd
+++ b/bin/moodle-docker-compose.cmd
@@ -1,0 +1,27 @@
+@ECHO OFF
+
+if "%MOODLE_DOCKER_DB%"=="" (
+    ECHO Error: MOODLE_DOCKER_DB is not set
+    EXIT /B 1
+)
+
+PUSHD %cd%
+CD %~dp0..
+SET BASEDIR=%cd%
+POPD
+
+SET COMPOSE_CONVERT_WINDOWS_PATHS=true
+
+SET DOCKERCOMPOSE=docker-compose -f "%BASEDIR%\base.yml"
+
+IF NOT "%MOODLE_DOCKER_DB%"=="pgsql" (
+    SET DOCKERCOMPOSE=%DOCKERCOMPOSE% -f "%BASEDIR%\db.%MOODLE_DOCKER_DB%.yml"
+)
+
+IF NOT "%MOODLE_DOCKER_BROWSER%"=="" (
+    IF NOT "%MOODLE_DOCKER_BROWSER%"=="firefox" (
+        SET DOCKERCOMPOSE=%DOCKERCOMPOSE% -f "%BASEDIR%\selenium.%MOODLE_DOCKER_BROWSER%.yml"
+    )
+)
+
+%DOCKERCOMPOSE% %*


### PR DESCRIPTION
Hi Dan, here's a batch file to let Windows users use your configs too. It's basically a straight port of your Unix one, although I've added COMPOSE_CONVERT_WINDOWS_PATHS so that MOODLE_DOCKER_WWWROOT can use normal Windows paths.

Hope it's useful!