### PR TITLE
Fix Chrome crashes by using host shared memory

### DIFF
--- a/selenium.chrome.yml
+++ b/selenium.chrome.yml
@@ -5,3 +5,5 @@ services:
       MOODLE_DOCKER_BROWSER: chrome
   selenium:
     image: selenium/standalone-chrome
+    volumes:
+        - /dev/shm:/dev/shm


### PR DESCRIPTION
Ref: https://github.com/SeleniumHQ/docker-selenium#running-the-images

(Should fix #12 - there are execution results there)