### PR TITLE
Add help for manual testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Started at 25-05-2017, 19:04
 15 steps (15 passed)
 1m35.32s (41.60Mb)
 
+# Install for manual testing (optional)
+bin/moodle-docker-compose exec webserver php admin/cli/install_database.php --agree-license --fullname="Docker moodle" --shortname="docker_moodle" --adminpass="test" --adminemail="admin@example.com"
+# Access http://localhost:8000/ on your browser
+
 # Shut down containers
 bin/moodle-docker-compose down
 ```


### PR DESCRIPTION
I've been using this for manual testing as well as behat / unit testing. I went to set it all up on my new environment and completely blanked as to why I couldn't use the site manually.

Because we create a config.php the error message is confusing (cannot access database) and I couldn't remember that we need to do cli DB install. (Even though I guess I did it last time).

Feel free to reject this pull request if we don't want to encourage manual testing :)