### PR TITLE
Add `Require all granted` to Behat faildumps dir

### DIFF
--- a/assets/web/apache2_faildumps.conf
+++ b/assets/web/apache2_faildumps.conf
@@ -1,5 +1,6 @@
 <Directory /var/www/behatfaildumps>
     Options +Indexes
+    Require all granted
 </Directory>
 
 <Location "/_/">


### PR DESCRIPTION
This seems to fix #333.

I just messed about with the `apache2_faildumps.conf` trying out various things and this worked.

For the life of me, I could not figure out why. More specifically, I don't understand why it stopped working before or if it really did stop working after moodlehq/moodle-php-apache#202.

Apache config is and always will remain beyond my intuition.

If someone could explain to me, _why_ this works, that would be great. Or maybe someone has a better idea for a fix.