### PR TITLE
Make compatible with all docker compose versions above 2

### DIFF
--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -23,7 +23,7 @@ export ASSETDIR="${basedir}/assets"
 
 # Test if we have docker compose v2 or v5, and keep quiet if we don't.
 ver=$(docker compose version > /dev/null 2>&1 && docker compose version --short) || true
-if [[ $ver =~ ^v?[2|5] ]]; then
+if [[ $ver =~ ^v?([2-9]|1[0-9]) ]]; then
   dockercompose="docker compose"
 else
   echo "Compose ${ver} is not available in Docker CLI, falling back to use docker-compose script"


### PR DESCRIPTION
The regular expression will now match on any version where:

 * the first number it 2 or greater
 * the first number is 1 followed by another number

 This should stop the script trying to fall back to the old  `docker compose` command again when docker advances to version 6 or greater of composer.

This is an improvement for pull request #342 to stop the a similar issue from happening in the future.